### PR TITLE
Adding the step to navigate to the app folder

### DIFF
--- a/docs/v2/getting-started/installation/index.md
+++ b/docs/v2/getting-started/installation/index.md
@@ -29,6 +29,12 @@ Once that's done, create your first Ionic app:
 $ ionic start cutePuppyPics --v2
 ```
 
+Now, navigate to your app folder 
+
+```bash
+$ cd cutePuppyPics
+```
+
 To run our app, just run
 
 ```bash


### PR DESCRIPTION
Before running the ionic serve command, user should be inside the ionic project. That step was missing in the documentation.

This will not be an issue for a experience ionic developer, but a beginner might get confused :)
